### PR TITLE
Entity: broadcast teleports as regular movements

### DIFF
--- a/src/entity/Entity.php
+++ b/src/entity/Entity.php
@@ -785,29 +785,21 @@ abstract class Entity{
 	}
 
 	protected function broadcastMovement(bool $teleport = false) : void{
-		if($teleport){
-			//TODO: HACK! workaround for https://github.com/pmmp/PocketMine-MP/issues/4394
-			//this happens because MoveActor*Packet doesn't clear interpolation targets on the client, so the entity
-			//snaps to the teleport position, but then lerps back to the original position if a normal movement for the
-			//entity was recently broadcasted. This can be seen with players throwing ender pearls.
-			//TODO: remove this if the bug ever gets fixed (lol)
-			foreach($this->hasSpawned as $player){
-				$this->despawnFrom($player);
-				$this->spawnTo($player);
-			}
-		}else{
-			NetworkBroadcastUtils::broadcastPackets($this->hasSpawned, [MoveActorAbsolutePacket::create(
-				$this->id,
-				$this->getOffsetPosition($this->location),
-				$this->location->pitch,
-				$this->location->yaw,
-				$this->location->yaw,
-				(
-					//TODO: if the above hack for #4394 gets removed, we should be setting FLAG_TELEPORT here
-					($this->onGround ? MoveActorAbsolutePacket::FLAG_GROUND : 0)
-				)
-			)]);
-		}
+		NetworkBroadcastUtils::broadcastPackets($this->hasSpawned, [MoveActorAbsolutePacket::create(
+			$this->id,
+			$this->getOffsetPosition($this->location),
+			$this->location->pitch,
+			$this->location->yaw,
+			$this->location->yaw,
+			(
+				//TODO: We should be setting FLAG_TELEPORT here to disable client-side movement interpolation, but it
+				//breaks player teleporting (observers see the player rubberband back to the pre-teleport position while
+				//the teleported player sees themselves at the correct position), and does nothing whatsoever for
+				//non-player entities (movement is still interpolated). Both of these are client bugs.
+				//See https://github.com/pmmp/PocketMine-MP/issues/4394
+			($this->onGround ? MoveActorAbsolutePacket::FLAG_GROUND : 0)
+			)
+		)]);
 	}
 
 	protected function broadcastMotion() : void{


### PR DESCRIPTION
https://github.com/pmmp/PocketMine-MP/commit/9a04481bec0c0faf6c4b5492990f37e4b93f89a5 add fix