### PR TITLE
BlockStateDowngrader: fix the downgrade of blocks with copied states

### DIFF
--- a/src/data/bedrock/block/downgrade/BlockStateDowngrader.php
+++ b/src/data/bedrock/block/downgrade/BlockStateDowngrader.php
@@ -68,16 +68,31 @@ final class BlockStateDowngrader{
 			$oldState = $blockStateData->getStates();
 			if(isset($schema->remappedStates[$oldName])){
 				foreach($schema->remappedStates[$oldName] as $remap){
-					if(count($oldState) !== count($remap->oldState)){
+					$shouldCopyStates = [];
+					foreach($remap->copiedState as $key){
+						if(isset($oldState[$key])){
+							$shouldCopyStates[$key] = $oldState[$key];
+						}
+					}
+					if(count($oldState) - count($shouldCopyStates) !== count($remap->oldState)){
 						continue; //try next state
 					}
 					foreach(Utils::stringifyKeys($oldState) as $k => $v){
+						if(isset($shouldCopyStates[$k])){
+							continue;
+						}
 						if(!isset($remap->oldState[$k]) || !$remap->oldState[$k]->equals($v)){
 							continue 2; //try next state
 						}
 					}
-
-					$blockStateData = new BlockStateData($remap->newName, $remap->newState, $resultVersion);
+					$newStates = $remap->newState;
+					foreach(Utils::stringifyKeys($shouldCopyStates) as $key => $value){
+						if(!isset($newStates[$key])){
+							$newStates[$key] = $value;
+						}
+						//is there need something else for isset?
+					}
+					$blockStateData = new BlockStateData($remap->newName, $newStates, $resultVersion);
 					continue 2; //try next schema
 				}
 			}


### PR DESCRIPTION
## Introduction
This PR fixes fix the downgrade of blocks with copied states, like oak_log to log

### Relevant issues

* Fixes #324

## Changes
### API changes
No

### Behavioural changes
the BlockStateDowngrader works properly now.

## Backwards compatibility
Any patch to BlockStateDowngrader may need an update.
Others have no impact.

## Follow-up
Nothing

Requires translations:
No

## Tests
Tested with oak_log and join server with version 575, it works.
