### PR TITLE
added 1.21.130 to ItemTypeDictionaryFromDataHelper

### DIFF
--- a/src/network/mcpe/convert/ItemTypeDictionaryFromDataHelper.php
+++ b/src/network/mcpe/convert/ItemTypeDictionaryFromDataHelper.php
@@ -46,6 +46,7 @@ final class ItemTypeDictionaryFromDataHelper{
 
 	private const PATHS = [
 		ProtocolInfo::CURRENT_PROTOCOL => "",
+		ProtocolInfo::PROTOCOL_1_21_130 => "-1.21.130",
 		ProtocolInfo::PROTOCOL_1_21_124 => "-1.21.120",
 		ProtocolInfo::PROTOCOL_1_21_120 => "-1.21.120",
 		ProtocolInfo::PROTOCOL_1_21_111 => "-1.21.111",


### PR DESCRIPTION
This PR adds the version `1.21.130` to the `ItemTypeDictionaryFromDataHelper`.

### Related issues & PRs

## Tests